### PR TITLE
Fix/explorer url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proton/cli",
   "description": "Proton CLI",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "author": "Syed Jafri @jafri",
   "bin": {
     "proton": "./bin/run"

--- a/src/apis/getExplorer.ts
+++ b/src/apis/getExplorer.ts
@@ -3,9 +3,9 @@ import { config } from "../storage/config"
 export function getExplorer () {
 	const chain: string = config.get('currentChain')
     if (chain === 'proton') {
-        return 'https://explorer.xprnetwork.org/'
+        return 'https://explorer.xprnetwork.org'
     } else if (chain === 'proton-test') {
-        return 'https://testnet.explorer.xprnetwork.org/'
+        return 'https://testnet.explorer.xprnetwork.org'
     }
 
     throw new Error('Chain not supported')

--- a/src/apis/getExplorer.ts
+++ b/src/apis/getExplorer.ts
@@ -2,7 +2,6 @@ import { config } from "../storage/config"
 
 export function getExplorer () {
 	const chain: string = config.get('currentChain')
-
     if (chain === 'proton') {
         return 'https://explorer.xprnetwork.org/'
     } else if (chain === 'proton-test') {

--- a/src/apis/getExplorer.ts
+++ b/src/apis/getExplorer.ts
@@ -4,9 +4,9 @@ export function getExplorer () {
 	const chain: string = config.get('currentChain')
 
     if (chain === 'proton') {
-        return 'https://protonscan.io'
+        return 'https://explorer.xprnetwork.org/'
     } else if (chain === 'proton-test') {
-        return 'https://testnet.protonscan.io'
+        return 'https://testnet.explorer.xprnetwork.org/'
     }
 
     throw new Error('Chain not supported')

--- a/src/commands/contract/clear.ts
+++ b/src/commands/contract/clear.ts
@@ -42,7 +42,7 @@ export default class CleanContract extends Command {
         })
 
         CliUx.ux.log(green(`WASM Successfully cleaned:`))
-        CliUx.ux.url(`View TX`, `https://${config.get('currentChain')}.ProtonScan.io/tx/${(res as any).transaction_id}?tab=traces`)
+        CliUx.ux.url(`View TX`, `${getExplorer()}/tx/${(res as any).transaction_id}?tab=traces`)
       } catch (e) {
         parseDetailsError(e)
       }

--- a/src/commands/contract/set.ts
+++ b/src/commands/contract/set.ts
@@ -267,7 +267,7 @@ export default class SetContract extends Command {
           })
 
           CliUx.ux.log(green(`WASM Successfully ${deployText}:`))
-          CliUx.ux.url(`View TX`, `https://${config.get('currentChain')}.ProtonScan.io/tx/${(res as any).transaction_id}?tab=traces`)
+          CliUx.ux.url(`View TX`, `${getExplorer()}/tx/${(res as any).transaction_id}?tab=traces`)
         } catch (e) {
           parseDetailsError(e)
         }


### PR DESCRIPTION
Fix the src/api/getExplorer.ts `getExplorer` method to return the new explorer URL. 
Replace hardcoded occurrences of the old `protonscan.io` by `getExplorer` method.
Bump version to 0.1.95.