### PR TITLE
fix: update ProtonProtocol references to XPRNetwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Proton CLI
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
 [![Version](https://img.shields.io/npm/v/@proton/cli.svg)](https://npmjs.org/package/@proton/cli)
 [![Downloads/week](https://img.shields.io/npm/dw/@proton/cli.svg)](https://npmjs.org/package/@proton/cli)
-[![License](https://img.shields.io/npm/l/@proton/cli.svg)](https://github.com/ProtonProtocol/proton-cli/blob/master/package.json)
+[![License](https://img.shields.io/npm/l/@proton/cli.svg)](https://github.com/XPRNetwork/proton-cli/blob/master/package.json)
 
 <!-- toc -->
 
@@ -150,7 +150,7 @@ DESCRIPTION
   Get Account Information
 ```
 
-_See code: [lib/commands/account/index.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/account/index.js)_
+_See code: [lib/commands/account/index.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/account/index.js)_
 
 ## `proton account:create ACCOUNT`
 
@@ -164,7 +164,7 @@ DESCRIPTION
   Create New Account
 ```
 
-_See code: [lib/commands/account/create.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/account/create.js)_
+_See code: [lib/commands/account/create.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/account/create.js)_
 
 ## `proton action CONTRACT [ACTION] [DATA] [AUTHORIZATION]`
 
@@ -184,7 +184,7 @@ DESCRIPTION
   Execute Action
 ```
 
-_See code: [lib/commands/action/index.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/action/index.js)_
+_See code: [lib/commands/action/index.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/action/index.js)_
 
 ## `proton block:get BLOCKNUMBER`
 
@@ -198,7 +198,7 @@ DESCRIPTION
   Get Block
 ```
 
-_See code: [lib/commands/block/get.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/block/get.js)_
+_See code: [lib/commands/block/get.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/block/get.js)_
 
 ## `proton boilerplate [FOLDER]`
 
@@ -215,7 +215,7 @@ DESCRIPTION
   Boilerplate a new Proton Project with contract, frontend and tests
 ```
 
-_See code: [lib/commands/boilerplate.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/boilerplate.js)_
+_See code: [lib/commands/boilerplate.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/boilerplate.js)_
 
 ## `proton chain:get`
 
@@ -232,7 +232,7 @@ ALIASES
   $ proton network
 ```
 
-_See code: [lib/commands/chain/get.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/chain/get.js)_
+_See code: [lib/commands/chain/get.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/chain/get.js)_
 
 ## `proton chain:info`
 
@@ -246,7 +246,7 @@ DESCRIPTION
   Get Chain Info
 ```
 
-_See code: [lib/commands/chain/info.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/chain/info.js)_
+_See code: [lib/commands/chain/info.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/chain/info.js)_
 
 ## `proton chain:list`
 
@@ -260,7 +260,7 @@ DESCRIPTION
   All Networks
 ```
 
-_See code: [lib/commands/chain/list.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/chain/list.js)_
+_See code: [lib/commands/chain/list.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/chain/list.js)_
 
 ## `proton chain:set [CHAIN]`
 
@@ -277,7 +277,7 @@ DESCRIPTION
   Set Chain
 ```
 
-_See code: [lib/commands/chain/set.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/chain/set.js)_
+_See code: [lib/commands/chain/set.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/chain/set.js)_
 
 ## `proton contract:abi ACCOUNT`
 
@@ -291,7 +291,7 @@ DESCRIPTION
   Get Contract ABI
 ```
 
-_See code: [lib/commands/contract/abi.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/contract/abi.js)_
+_See code: [lib/commands/contract/abi.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/contract/abi.js)_
 
 ## `proton contract:clear ACCOUNT`
 
@@ -309,7 +309,7 @@ DESCRIPTION
   Clean Contract
 ```
 
-_See code: [lib/commands/contract/clear.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/contract/clear.js)_
+_See code: [lib/commands/contract/clear.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/contract/clear.js)_
 
 ## `proton contract:enableinline ACCOUNT`
 
@@ -329,7 +329,7 @@ DESCRIPTION
   Enable Inline Actions on a Contract
 ```
 
-_See code: [lib/commands/contract/enableinline.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/contract/enableinline.js)_
+_See code: [lib/commands/contract/enableinline.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/contract/enableinline.js)_
 
 ## `proton contract:set ACCOUNT SOURCE`
 
@@ -349,7 +349,7 @@ DESCRIPTION
   Deploy Contract (WASM + ABI)
 ```
 
-_See code: [lib/commands/contract/set.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/contract/set.js)_
+_See code: [lib/commands/contract/set.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/contract/set.js)_
 
 ## `proton encode:name ACCOUNT`
 
@@ -363,7 +363,7 @@ DESCRIPTION
   Encode Name
 ```
 
-_See code: [lib/commands/encode/name.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/encode/name.js)_
+_See code: [lib/commands/encode/name.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/encode/name.js)_
 
 ## `proton encode:symbol SYMBOL PRECISION`
 
@@ -377,7 +377,7 @@ DESCRIPTION
   Encode Symbol
 ```
 
-_See code: [lib/commands/encode/symbol.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/encode/symbol.js)_
+_See code: [lib/commands/encode/symbol.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/encode/symbol.js)_
 
 ## `proton endpoint`
 
@@ -409,7 +409,7 @@ DESCRIPTION
   Restore default enpoint
 ```
 
-_See code: [lib/commands/endpoint/default.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/endpoint/default.js)_
+_See code: [lib/commands/endpoint/default.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/endpoint/default.js)_
 
 ## `proton endpoint:get`
 
@@ -426,7 +426,7 @@ ALIASES
   $ proton endpoint
 ```
 
-_See code: [lib/commands/endpoint/get.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/endpoint/get.js)_
+_See code: [lib/commands/endpoint/get.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/endpoint/get.js)_
 
 ## `proton endpoint:set [ENDPOINT]`
 
@@ -443,7 +443,7 @@ DESCRIPTION
   Set current enpoint
 ```
 
-_See code: [lib/commands/endpoint/set.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/endpoint/set.js)_
+_See code: [lib/commands/endpoint/set.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/endpoint/set.js)_
 
 ## `proton faucet`
 
@@ -457,7 +457,7 @@ DESCRIPTION
   List all faucets
 ```
 
-_See code: [lib/commands/faucet/index.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/faucet/index.js)_
+_See code: [lib/commands/faucet/index.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/faucet/index.js)_
 
 ## `proton faucet:claim SYMBOL AUTHORIZATION`
 
@@ -475,7 +475,7 @@ DESCRIPTION
   Claim faucet
 ```
 
-_See code: [lib/commands/faucet/claim.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/faucet/claim.js)_
+_See code: [lib/commands/faucet/claim.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/faucet/claim.js)_
 
 ## `proton generate:action`
 
@@ -494,7 +494,7 @@ DESCRIPTION
   Add extra actions to the smart contract
 ```
 
-_See code: [lib/commands/generate/action.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/generate/action.js)_
+_See code: [lib/commands/generate/action.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/generate/action.js)_
 
 ## `proton generate:contract CONTRACTNAME`
 
@@ -514,7 +514,7 @@ DESCRIPTION
   Create new smart contract
 ```
 
-_See code: [lib/commands/generate/contract.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/generate/contract.js)_
+_See code: [lib/commands/generate/contract.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/generate/contract.js)_
 
 ## `proton generate:inlineaction ACTIONNAME`
 
@@ -536,7 +536,7 @@ DESCRIPTION
   Add inline action for the smart contract
 ```
 
-_See code: [lib/commands/generate/inlineaction.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/generate/inlineaction.js)_
+_See code: [lib/commands/generate/inlineaction.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/generate/inlineaction.js)_
 
 ## `proton generate:table TABLENAME`
 
@@ -560,7 +560,7 @@ DESCRIPTION
   Add table for the smart contract
 ```
 
-_See code: [lib/commands/generate/table.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/generate/table.js)_
+_See code: [lib/commands/generate/table.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/generate/table.js)_
 
 ## `proton help [COMMAND]`
 
@@ -594,7 +594,7 @@ DESCRIPTION
   Manage Keys
 ```
 
-_See code: [lib/commands/key/add.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/key/add.js)_
+_See code: [lib/commands/key/add.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/key/add.js)_
 
 ## `proton key:generate`
 
@@ -608,7 +608,7 @@ DESCRIPTION
   Generate Key
 ```
 
-_See code: [lib/commands/key/generate.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/key/generate.js)_
+_See code: [lib/commands/key/generate.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/key/generate.js)_
 
 ## `proton key:get PUBLICKEY`
 
@@ -622,7 +622,7 @@ DESCRIPTION
   Find private key for public key
 ```
 
-_See code: [lib/commands/key/get.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/key/get.js)_
+_See code: [lib/commands/key/get.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/key/get.js)_
 
 ## `proton key:list`
 
@@ -636,7 +636,7 @@ DESCRIPTION
   List All Key
 ```
 
-_See code: [lib/commands/key/list.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/key/list.js)_
+_See code: [lib/commands/key/list.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/key/list.js)_
 
 ## `proton key:lock`
 
@@ -650,7 +650,7 @@ DESCRIPTION
   Lock Keys with password
 ```
 
-_See code: [lib/commands/key/lock.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/key/lock.js)_
+_See code: [lib/commands/key/lock.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/key/lock.js)_
 
 ## `proton key:remove [PRIVATEKEY]`
 
@@ -664,7 +664,7 @@ DESCRIPTION
   Remove Key
 ```
 
-_See code: [lib/commands/key/remove.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/key/remove.js)_
+_See code: [lib/commands/key/remove.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/key/remove.js)_
 
 ## `proton key:reset`
 
@@ -678,7 +678,7 @@ DESCRIPTION
   Reset password (Caution: deletes all private keys stored)
 ```
 
-_See code: [lib/commands/key/reset.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/key/reset.js)_
+_See code: [lib/commands/key/reset.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/key/reset.js)_
 
 ## `proton key:unlock [PASSWORD]`
 
@@ -692,7 +692,7 @@ DESCRIPTION
   Unlock all keys (Caution: Your keys will be stored in plaintext on disk)
 ```
 
-_See code: [lib/commands/key/unlock.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/key/unlock.js)_
+_See code: [lib/commands/key/unlock.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/key/unlock.js)_
 
 ## `proton msig:approve PROPOSER PROPOSAL AUTH`
 
@@ -706,7 +706,7 @@ DESCRIPTION
   Multisig Approve
 ```
 
-_See code: [lib/commands/msig/approve.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/msig/approve.js)_
+_See code: [lib/commands/msig/approve.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/msig/approve.js)_
 
 ## `proton msig:cancel PROPOSALNAME AUTH`
 
@@ -720,7 +720,7 @@ DESCRIPTION
   Multisig Cancel
 ```
 
-_See code: [lib/commands/msig/cancel.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/msig/cancel.js)_
+_See code: [lib/commands/msig/cancel.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/msig/cancel.js)_
 
 ## `proton msig:exec PROPOSER PROPOSAL AUTH`
 
@@ -734,7 +734,7 @@ DESCRIPTION
   Multisig Execute
 ```
 
-_See code: [lib/commands/msig/exec.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/msig/exec.js)_
+_See code: [lib/commands/msig/exec.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/msig/exec.js)_
 
 ## `proton msig:propose PROPOSALNAME ACTIONS AUTH`
 
@@ -752,7 +752,7 @@ DESCRIPTION
   Multisig Propose
 ```
 
-_See code: [lib/commands/msig/propose.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/msig/propose.js)_
+_See code: [lib/commands/msig/propose.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/msig/propose.js)_
 
 ## `proton network`
 
@@ -784,7 +784,7 @@ DESCRIPTION
   Update Permission
 ```
 
-_See code: [lib/commands/permission/index.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/permission/index.js)_
+_See code: [lib/commands/permission/index.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/permission/index.js)_
 
 ## `proton permission:link ACCOUNT PERMISSION CONTRACT [ACTION]`
 
@@ -801,7 +801,7 @@ DESCRIPTION
   Link Auth
 ```
 
-_See code: [lib/commands/permission/link.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/permission/link.js)_
+_See code: [lib/commands/permission/link.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/permission/link.js)_
 
 ## `proton permission:unlink ACCOUNT CONTRACT [ACTION]`
 
@@ -818,7 +818,7 @@ DESCRIPTION
   Unlink Auth
 ```
 
-_See code: [lib/commands/permission/unlink.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/permission/unlink.js)_
+_See code: [lib/commands/permission/unlink.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/permission/unlink.js)_
 
 ## `proton psr URI`
 
@@ -832,7 +832,7 @@ DESCRIPTION
   Create Session
 ```
 
-_See code: [lib/commands/psr/index.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/psr/index.js)_
+_See code: [lib/commands/psr/index.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/psr/index.js)_
 
 ## `proton ram`
 
@@ -846,7 +846,7 @@ DESCRIPTION
   List Ram price
 ```
 
-_See code: [lib/commands/ram/index.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/ram/index.js)_
+_See code: [lib/commands/ram/index.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/ram/index.js)_
 
 ## `proton ram:buy BUYER RECEIVER BYTES`
 
@@ -868,7 +868,7 @@ DESCRIPTION
   Claim faucet
 ```
 
-_See code: [lib/commands/ram/buy.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/ram/buy.js)_
+_See code: [lib/commands/ram/buy.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/ram/buy.js)_
 
 ## `proton rpc:accountsbyauthorizers AUTHORIZATIONS [KEYS]`
 
@@ -882,7 +882,7 @@ DESCRIPTION
   Get Accounts by Authorization
 ```
 
-_See code: [lib/commands/rpc/accountsbyauthorizers.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/rpc/accountsbyauthorizers.js)_
+_See code: [lib/commands/rpc/accountsbyauthorizers.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/rpc/accountsbyauthorizers.js)_
 
 ## `proton scan ACCOUNT`
 
@@ -896,7 +896,7 @@ DESCRIPTION
   Open Account in Proton Scan
 ```
 
-_See code: [lib/commands/scan/index.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/scan/index.js)_
+_See code: [lib/commands/scan/index.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/scan/index.js)_
 
 ## `proton table CONTRACT [TABLE] [SCOPE]`
 
@@ -920,7 +920,7 @@ DESCRIPTION
   Get Table Storage Rows
 ```
 
-_See code: [lib/commands/table/index.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/table/index.js)_
+_See code: [lib/commands/table/index.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/table/index.js)_
 
 ## `proton transaction JSON`
 
@@ -934,7 +934,7 @@ DESCRIPTION
   Execute Transaction
 ```
 
-_See code: [lib/commands/transaction/index.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/transaction/index.js)_
+_See code: [lib/commands/transaction/index.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/transaction/index.js)_
 
 ## `proton transaction:get ID`
 
@@ -948,7 +948,7 @@ DESCRIPTION
   Get Transaction by Transaction ID
 ```
 
-_See code: [lib/commands/transaction/get.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/transaction/get.js)_
+_See code: [lib/commands/transaction/get.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/transaction/get.js)_
 
 ## `proton transaction:push TRANSACTION`
 
@@ -965,7 +965,7 @@ DESCRIPTION
   Push Transaction
 ```
 
-_See code: [lib/commands/transaction/push.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/transaction/push.js)_
+_See code: [lib/commands/transaction/push.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/transaction/push.js)_
 
 ## `proton version`
 
@@ -979,6 +979,6 @@ DESCRIPTION
   Version of CLI
 ```
 
-_See code: [lib/commands/version.js](https://github.com/ProtonProtocol/proton-cli/blob/v0.1.95/lib/commands/version.js)_
+_See code: [lib/commands/version.js](https://github.com/XPRNetwork/proton-cli/blob/v0.1.95/lib/commands/version.js)_
 
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
   "bin": {
     "proton": "./bin/run"
   },
-  "bugs": "https://github.com/ProtonProtocol/proton-cli/issues",
+  "bugs": "https://github.com/XPRNetwork/proton-cli/issues",
   "files": [
     "/bin",
     "/lib",
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json"
   ],
-  "homepage": "https://github.com/ProtonProtocol/proton-cli",
+  "homepage": "https://github.com/XPRNetwork/proton-cli",
   "keywords": [
     "oclif"
   ],
@@ -39,7 +39,7 @@
       }
     }
   },
-  "repository": "ProtonProtocol/proton-cli",
+  "repository": "XPRNetwork/proton-cli",
   "scripts": {
     "build": "npm run prepack && npm run postpack",
     "postpack": "rm -f oclif.manifest.json",

--- a/src/commands/boilerplate.ts
+++ b/src/commands/boilerplate.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs'
 import * as rimraf from 'rimraf'
 import { CliUx } from '@oclif/core'
 
-const BOILERPLATE_URL = 'https://github.com/ProtonProtocol/proton-boilerplate.git'
+const BOILERPLATE_URL = 'https://github.com/XPRNetwork/proton-boilerplate.git'
 const BOILERPLATE_BRANCH = 'master'
 
 export default class Boilerplate extends Command {


### PR DESCRIPTION
## Summary

Update all GitHub URLs and references from the old `ProtonProtocol` organization to `XPRNetwork` to reflect the current repository location.

## Changes

- **package.json**: Updated `bugs`, `homepage`, and `repository` URLs
- **README.md**: Updated all "See code" documentation links (54 occurrences)
- **src/commands/boilerplate.ts**: Updated boilerplate repo URL

## Before/After

```diff
- https://github.com/ProtonProtocol/proton-cli
+ https://github.com/XPRNetwork/proton-cli

- https://github.com/ProtonProtocol/proton-boilerplate.git
+ https://github.com/XPRNetwork/proton-boilerplate.git
```

## Test Plan

- [x] Verified no remaining `ProtonProtocol` references in source files
- [ ] `npm run build` passes
- [ ] `proton boilerplate` command works with new URL

---

🤖 Generated with [Claude Code](https://claude.ai/code)